### PR TITLE
Add host variable to allow subdomain testing

### DIFF
--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -9,8 +9,10 @@ module Watir
     def initialize(*args)
       Rails.boot
       original_initialize *args
+      @host = Rails.host
     end
 
+    attr_accessor :host
     # @private
     alias_method :original_goto, :goto
 
@@ -25,7 +27,7 @@ module Watir
     #
     # @param [String] url URL to be navigated to.
     def goto(url)
-      url = "http://#{Rails.host}:#{Rails.port}#{url}" unless url =~ %r{^https?://}i || url == "about:blank"
+      url = "http://#{@host}:#{Rails.port}#{url}" unless url =~ %r{^https?://}i || url == "about:blank"
       original_goto url
     end
   end


### PR DESCRIPTION
I'm using watir-rails to test my application which uses subdomains. I need to be able to set a specific host for the request (even if it's still connecting to 127.0.0.1). Using the url to do that is kind of annoying since you need to retrieve the Rails.port, this solution seems a bit better.
