### PR TITLE
Allow to set ignore_exceptions option

### DIFF
--- a/lib/watir/rails.rb
+++ b/lib/watir/rails.rb
@@ -76,7 +76,7 @@ module Watir
       #
       # @return [Boolean] true if exceptions should be ignored, false otherwise.
       def ignore_exceptions?
-        unless @ignore_exceptions
+        if @ignore_exceptions.nil?
           show_exceptions = if legacy_rails?
                    ::Rails.configuration.action_dispatch.show_exceptions
                  else

--- a/spec/watir/rails_spec.rb
+++ b/spec/watir/rails_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Watir::Rails do
   before do
     described_class.stub(:warn)
-    described_class.ignore_exceptions = false
+    described_class.ignore_exceptions = nil
     described_class.instance_eval { @middleware = @port = @server_thread = @host = @app = nil }
   end
 
@@ -53,9 +53,14 @@ describe Watir::Rails do
       described_class.should be_ignore_exceptions
     end
 
+    it "false if @ignore_exceptions is set to false" do
+      described_class.ignore_exceptions = false
+      described_class.should_not be_ignore_exceptions
+    end
+
     it "true if Rails.action_dispatch.show_exceptions is set to true for older Rails" do
       described_class.stub(legacy_rails?: true)
-      described_class.ignore_exceptions = false
+      described_class.ignore_exceptions = nil
       ::Rails.stub_chain(:configuration, :action_dispatch, :show_exceptions).and_return(true)
 
       described_class.should be_ignore_exceptions
@@ -63,7 +68,7 @@ describe Watir::Rails do
 
     it "true if Rails.action_dispatch.show_exceptions is set to true for Rails 3" do
       described_class.stub(legacy_rails?: false)
-      described_class.ignore_exceptions = false
+      described_class.ignore_exceptions = nil
       ::Rails.stub_chain(:application, :config, :action_dispatch, :show_exceptions).and_return(true)
 
       described_class.should be_ignore_exceptions
@@ -71,7 +76,7 @@ describe Watir::Rails do
 
     it "false if Rails.action_dispatch.show_exceptions is set to false for older Rails" do
       described_class.stub(legacy_rails?: true)
-      described_class.ignore_exceptions = false
+      described_class.ignore_exceptions = nil
       ::Rails.stub_chain(:configuration, :action_dispatch, :show_exceptions).and_return(false)
 
       described_class.should_not be_ignore_exceptions
@@ -79,7 +84,7 @@ describe Watir::Rails do
 
     it "true if Rails.action_dispatch.show_exceptions is set to false for Rails 3" do
       described_class.stub(legacy_rails?: false)
-      described_class.ignore_exceptions = false
+      described_class.ignore_exceptions = nil
       ::Rails.stub_chain(:application, :config, :action_dispatch, :show_exceptions).and_return(false)
 
       described_class.should_not be_ignore_exceptions


### PR DESCRIPTION
It's impossible to set `ignore_exceptions` to `false` directly with the `Watir::Rails.ignore_exceptions = false` with the current code. The fix fixes this.

The problem is that `Rails.application.config.action_dispatch.show_exceptions` is always `true` in reality. Seems that `watir-rails` initializes `Rails` application firstly with the default values for action dispatch library on require `watir-rails` in the `env.rb` and then immediately after this `ignore_exceptions` method is called not waiting for loading `environment/test.rb`. I think it's better to emulate the reals situation in tests - `@ignore_exceptions` is `nil` default.