### PR TITLE
Allow to customize default server handler and count requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rvm:
  - ruby-head
 before_install:
   - |
-  if [[ "$BUNDLER_VERSION" ]]
-  then
-    rvm @default,@global do gem uninstall bundler --all --executables
-    gem install bundler -v "$BUNDLER_VERSION"
-  fi
+    if [[ "$BUNDLER_VERSION" ]]
+    then
+      rvm @default,@global do gem uninstall bundler --all --executables
+      gem install bundler -v "$BUNDLER_VERSION"
+    fi
   - bundle --version
 matrix:
   - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,11 @@
 rvm:
- - 2.6.3
- - 2.5.5
- - ruby-head
-before_install:
-  - |
-    if [[ "$BUNDLER_VERSION" ]]
-    then
-      rvm @default,@global do gem uninstall bundler --all --executables
-      gem install bundler -v "$BUNDLER_VERSION"
-    fi
-  - bundle --version
-matrix:
-  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-2.x
-  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-3.x BUNDLER_VERSION=1.17.3
-  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-4.x BUNDLER_VERSION=1.17.3
-  - BUNDLE_GEMFILE=$PWD/Gemfile
+  - 2.6.3
+  - ruby-head
+gemfile:
+  - gemfiles/Gemfile.rails-2.x
+  - gemfiles/Gemfile.rails-3.x
+  - gemfiles/Gemfile.rails-4.x
+  - Gemfile
 notifications:
   recipients:
     - jarmo@jarmopertman.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,19 @@ rvm:
  - 2.6.3
  - 2.5.5
  - ruby-head
-gemfile:
-  - gemfiles/Gemfile.rails-2.x
-  - gemfiles/Gemfile.rails-3.x
-  - gemfiles/Gemfile.rails-4.x
-  - Gemfile
+before_install:
+  - |
+  if [[ "$BUNDLER_VERSION" ]]
+  then
+    rvm @default,@global do gem uninstall bundler --all --executables
+    gem install bundler -v "$BUNDLER_VERSION"
+  fi
+  - bundle --version
+matrix:
+  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-2.x
+  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-3.x BUNDLER_VERSION=1.17.3
+  - BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.rails-4.x BUNDLER_VERSION=1.17.3
+  - BUNDLE_GEMFILE=$PWD/Gemfile
 notifications:
   recipients:
     - jarmo@jarmopertman.com

--- a/lib/watir/rails.rb
+++ b/lib/watir/rails.rb
@@ -67,6 +67,13 @@ module Watir
         @middleware.error
       end
 
+      # Returns true if there are pending requests to server.
+      #
+      # @return [Boolean]
+      def pending_requests?
+        @middleware.pending_requests?
+      end
+
       # Set error rescued by the middleware.
       #
       # @param value

--- a/lib/watir/rails/middleware.rb
+++ b/lib/watir/rails/middleware.rb
@@ -2,25 +2,49 @@ module Watir
   class Rails
     # @private
     class Middleware
+      class PendingRequestsCounter
+        attr_reader :value
+
+        def initialize
+          @value = 0
+          @mutex = Mutex.new
+        end
+
+        def increment
+          @mutex.synchronize { @value += 1 }
+        end
+
+        def decrement
+          @mutex.synchronize { @value -= 1 }
+        end
+      end
+
       attr_accessor :error
 
       def initialize(app)
         @app = app
+        @counter = PendingRequestsCounter.new
+      end
+
+      def pending_requests?
+        @counter.value > 0
       end
 
       def call(env)
         if env["PATH_INFO"] == "/__identify__"
           [200, {}, [@app.object_id.to_s]]
         else
+          @counter.increment
           begin
             @app.call(env)
           rescue => e
             @error = e
             raise e
+          ensure
+            @counter.decrement
           end
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
1. Sometimes a user might want to customize a default server handler if it's not good for any reason (e.g. he uses an exotic server). My company has a bit different Puma handler so we're doing this:

```ruby
Watir::Rails.server = lambda do |app, port|
  require 'rack/handler/puma'

  options = {Port: port, Threads: '0:4', workers: 0, daemon: false, Silent: true}
  conf = Rack::Handler::Puma.config(app, options)

  Puma::Server.new(conf.app, ::Puma::Events.strings, conf.options).tap do |s|
    s.binder.parse conf.options[:binds], s.events
    s.min_threads = conf.options[:min_threads]
    s.max_threads = conf.options[:max_threads]
  end.run.join
end
```

2. It's useful to be able to postpone teardown in tests until all the requests are completed, so it's great to have Watir::Rails provide API for that. This is based on [Capybara's server middleware](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/server/middleware.rb) implementation:

```ruby
Watir::Wait.while { Watir::Rails.pending_requests? }
```