### PR TITLE
Handle EOFError while checking if Rails server is running

### DIFF
--- a/lib/watir/rails.rb
+++ b/lib/watir/rails.rb
@@ -112,7 +112,7 @@ module Watir
         if res.is_a?(Net::HTTPSuccess) or res.is_a?(Net::HTTPRedirection)
           return res.body == @app.object_id.to_s
         end
-      rescue Errno::ECONNREFUSED, Errno::EBADF
+      rescue Errno::ECONNREFUSED, Errno::EBADF, EOFError
         return false
       end
 


### PR DESCRIPTION
Unsuccessful request fails with `EOFError` here (linux x86_64), so add handling for it.