### PR TITLE
Set the @port before actually trying to see if an existing server is running

### DIFF
--- a/lib/watir/rails.rb
+++ b/lib/watir/rails.rb
@@ -25,9 +25,10 @@ module Watir
       #
       # @param [Integer] port port for the Rails up to run on. If omitted random port will be picked.
       def boot(port: nil)
+        @port = port || find_available_port
+
         unless running?
           @middleware = Middleware.new(app)
-          @port = port || find_available_port
 
           @server_thread = Thread.new do
             server.call @middleware, @port


### PR DESCRIPTION
This PR fixes the #26 issue by actually making sure the `@port` instance variable is set before checking to see if the server is running.