### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Run watir-rails CI
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.ruby-version == 'debug' }}
+    strategy:
+      matrix:
+        BUNDLE_GEMFILE: [gemfiles/Gemfile.rails-3.x, gemfiles/Gemfile.rails-4.x, Gemfile]
+        ruby-version: [2.6.3, debug]
+        exclude:
+          # rails-4.2 requires BigDecimal.new (dropped in ruby-2.7)
+          - { BUNDLE_GEMFILE: gemfiles/Gemfile.rails-4.x, ruby-version: debug }
+          # The issue on rails-3.2 + head is json-1.8.6 compat (simplecov
+          # uses it), we could potentially workaround it using, for example, Oj
+          - { BUNDLE_GEMFILE: gemfiles/Gemfile.rails-3.x, ruby-version: debug }
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.BUNDLE_GEMFILE }}
+      LCOV_REPORT_PATH: './coverage/lcov.info'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          # rails < 5 doesn't support bundler-2
+          bundler: 1
+          bundler-cache: true
+
+      - run: bundle exec rake
+
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ env.LCOV_REPORT_PATH }}
+          parallel: true
+          flag-name: ruby-${{ matrix.ruby-version }}_gemfile-${{ matrix.BUNDLE_GEMFILE }}
+
+  coveralls:
+    needs: test
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ rvm:
   - 2.6.3
   - ruby-head
 gemfile:
-  - gemfiles/Gemfile.rails-2.x
   - gemfiles/Gemfile.rails-3.x
   - gemfiles/Gemfile.rails-4.x
   - Gemfile
@@ -12,4 +11,3 @@ notifications:
 matrix:
   allow_failures:
     - rvm: ruby-head
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "coveralls", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false

--- a/gemfiles/Gemfile.rails-2.x
+++ b/gemfiles/Gemfile.rails-2.x
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: ".."
-
-gem "coveralls", require: false
-gem "rails", "~> 2.0"

--- a/gemfiles/Gemfile.rails-3.x
+++ b/gemfiles/Gemfile.rails-3.x
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "coveralls", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 gem "rails", "~> 3.0"

--- a/gemfiles/Gemfile.rails-4.x
+++ b/gemfiles/Gemfile.rails-4.x
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "coveralls", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 gem "rails", "~> 4.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,17 @@
 require "simplecov"
-require 'coveralls'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+if ENV["LCOV_REPORT_PATH"]
+  require "simplecov-lcov"
+
+  SimpleCov::Formatter::LcovFormatter.config do |c|
+    c.report_with_single_file = true
+    root_dir = File.expand_path('..', __dir__)
+    c.single_report_path = File.expand_path(ENV.fetch('LCOV_REPORT_PATH'), root_dir)
+  end
+
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+end
+
 SimpleCov.start
 
 # Make sure that fake watir gems are loaded for specs.

--- a/spec/watir/rails_spec.rb
+++ b/spec/watir/rails_spec.rb
@@ -81,17 +81,7 @@ describe Watir::Rails do
       expect(described_class).not_to be_ignore_exceptions
     end
 
-    it "true if Rails.action_dispatch.show_exceptions is set to true for older Rails" do
-      allow(described_class).to receive_messages(legacy_rails?: true)
-      described_class.ignore_exceptions = nil
-      allow(::Rails).to receive_message_chain(:configuration,
-        :action_dispatch, :show_exceptions).and_return(true)
-
-      expect(described_class).to be_ignore_exceptions
-    end
-
-    it "true if Rails.action_dispatch.show_exceptions is set to true for Rails 3" do
-      allow(described_class).to receive_messages(legacy_rails?: false)
+    it "true if Rails.action_dispatch.show_exceptions is set to true" do
       described_class.ignore_exceptions = nil
       allow(::Rails).to receive_message_chain(:application,
         :config, :action_dispatch, :show_exceptions).and_return(true)
@@ -99,17 +89,7 @@ describe Watir::Rails do
       expect(described_class).to be_ignore_exceptions
     end
 
-    it "false if Rails.action_dispatch.show_exceptions is set to false for older Rails" do
-      allow(described_class).to receive_messages(legacy_rails?: true)
-      described_class.ignore_exceptions = nil
-      allow(::Rails).to receive_message_chain(:configuration,
-        :action_dispatch, :show_exceptions).and_return(false)
-
-      expect(described_class).not_to be_ignore_exceptions
-    end
-
-    it "true if Rails.action_dispatch.show_exceptions is set to false for Rails 3" do
-      allow(described_class).to receive_messages(legacy_rails?: false)
+    it "true if Rails.action_dispatch.show_exceptions is set to false" do
       described_class.ignore_exceptions = nil
       allow(::Rails).to receive_message_chain(:application,
         :config, :action_dispatch, :show_exceptions).and_return(false)

--- a/watir-rails.gemspec
+++ b/watir-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
   gem.version       = Watir::Rails::VERSION
-  gem.required_ruby_version = ">= 2.2.0"
+  gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_dependency "rack"
   gem.add_dependency "rails", ">= 3"

--- a/watir-rails.gemspec
+++ b/watir-rails.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
   gem.version       = Watir::Rails::VERSION
+  gem.required_ruby_version = ">= 2.2.0"
 
   gem.add_dependency "rack"
-  gem.add_dependency "rails"
+  gem.add_dependency "rails", ">= 3"
   gem.add_dependency "watir", ">= 6.0.0.beta4"
 
   gem.add_development_dependency "yard"


### PR DESCRIPTION
Travis is harder to configure and slower, let's switch to [rather] new fancy GitHub Actions.

~~Add expanded martix with every ruby/rails version supported (initially to determining what we actually support, but it quite fast, so wouldn't hurt anyway). 
Since we're running specs more times due to expanded matrix — `.server=` spec flakiness became more pronounces, fix it.
Since we're switching away from `coveralls` gem to GH Actions action for submitting coverage — let's enable branch coverage if supported, it wouldn't hurt.
And then add smoke test with real browser and real rails app to reduce test matrix a little.~~
Will be added in the next PR after GH actions is in master.