### PR TITLE
Drop old Ruby and Rails support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,8 @@ jobs:
     continue-on-error: ${{ matrix.ruby-version == 'debug' }}
     strategy:
       matrix:
-        BUNDLE_GEMFILE: [gemfiles/Gemfile.rails-3.x, gemfiles/Gemfile.rails-4.x, Gemfile]
-        ruby-version: [2.6.3, debug]
-        exclude:
-          # rails-4.2 requires BigDecimal.new (dropped in ruby-2.7)
-          - { BUNDLE_GEMFILE: gemfiles/Gemfile.rails-4.x, ruby-version: debug }
-          # The issue on rails-3.2 + head is json-1.8.6 compat (simplecov
-          # uses it), we could potentially workaround it using, for example, Oj
-          - { BUNDLE_GEMFILE: gemfiles/Gemfile.rails-3.x, ruby-version: debug }
+        BUNDLE_GEMFILE: [gemfiles/Gemfile.rails-6.0, gemfiles/Gemfile.rails-6.1, Gemfile]
+        ruby-version: [3.0, debug]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.BUNDLE_GEMFILE }}
       LCOV_REPORT_PATH: './coverage/lcov.info'
@@ -30,8 +24,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          # rails < 5 doesn't support bundler-2
-          bundler: 1
           bundler-cache: true
 
       - run: bundle exec rake

--- a/gemfiles/Gemfile.rails-6.0
+++ b/gemfiles/Gemfile.rails-6.0
@@ -4,4 +4,4 @@ gemspec path: ".."
 
 gem "simplecov", require: false
 gem "simplecov-lcov", require: false
-gem "rails", "~> 4.0"
+gem "rails", "~> 6.0.0"

--- a/gemfiles/Gemfile.rails-6.1
+++ b/gemfiles/Gemfile.rails-6.1
@@ -4,4 +4,4 @@ gemspec path: ".."
 
 gem "simplecov", require: false
 gem "simplecov-lcov", require: false
-gem "rails", "~> 3.0"
+gem "rails", "~> 6.1.0"

--- a/watir-rails.gemspec
+++ b/watir-rails.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
   gem.version       = Watir::Rails::VERSION
-  gem.required_ruby_version = ">= 2.4.0"
+  gem.required_ruby_version = ">= 3.0.0"
 
   gem.add_dependency "rack"
-  gem.add_dependency "rails", ">= 3"
+  gem.add_dependency "rails", ">= 6"
   gem.add_dependency "watir", ">= 6.0.0.beta4"
 
   gem.add_development_dependency "yard"


### PR DESCRIPTION
Require Ruby >= 3.0 and Rails >= 6.0

Ruby 2.7 is about to end its life: https://www.ruby-lang.org/en/downloads/branches/
Rails < 6 are no longer supported: https://guides.rubyonrails.org/maintenance_policy.html
