### PR TITLE
Follow rack/rackup gem and Ruby changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem "simplecov", require: false
 gem "simplecov-lcov", require: false
+gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ gemspec
 
 gem "simplecov", require: false
 gem "simplecov-lcov", require: false
-gem "webrick"

--- a/lib/watir/rails.rb
+++ b/lib/watir/rails.rb
@@ -146,8 +146,14 @@ module Watir
           rescue LoadError
           end
 
-          require 'rack/handler/webrick'
-          Rack::Handler::WEBrick.run(app, :Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
+          begin
+            require 'rack/handler/webrick'
+            return Rack::Handler::WEBrick.run(app, :Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
+          rescue LoadError
+          end
+
+          require 'rackup/handler/webrick'
+          Rackup::Handler::WEBrick.run(app, :Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
         end
       end
     end

--- a/watir-rails.gemspec
+++ b/watir-rails.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "yard"
   gem.add_development_dependency "redcarpet"
   gem.add_development_dependency "rspec", "~> 3.0"
+  gem.add_development_dependency "webrick"
 end


### PR DESCRIPTION
This Pull Request tries to follow the changes that were in the Rack, Rackup, and Ruby side a couple of months ago.

What changed in Ruby?
They dropped webrick, this is not a default gem anymore from Ruby 3.0.

What changed in the Rack gem?
They outsourced the Rack handler into the Rackup gem from Rack 3.0.

What changed in the Rackup gem?
They removed rack shims and webrick dependency from Rackup 2.2.0.

Because of these changes, the watir-rails gem is not working anymore if we are using the webrick gem. The puma and thin gems handled these changes, but webrick did not. If somebody updates the gems and uses webrick, then they have to monkey-patch watir-rails to make them work again, or have to replace webrick with either puma or thin.
